### PR TITLE
fixed kronecker.sparse_tile

### DIFF
--- a/asvgp/kronecker.py
+++ b/asvgp/kronecker.py
@@ -20,7 +20,7 @@ def sparse_tile(A, repeats):
     data = np.tile(A.data, repeats)
     row = np.zeros(data.shape)
     for i in range(0, repeats):
-        row[i*n:(i+1)*n] = A.row + i*repeats
+        row[i*n:(i+1)*n] = A.row + i*A.shape[0]
     col = np.tile(A.col, repeats)
     return sparse.csr_matrix((data, (row, col)), shape=(A.shape[0] * repeats, A.shape[1]))
 


### PR DESCRIPTION
There was a small error in `sparse_tile` in `kronecker.py` that was causing some problems when considering different numbers of inducing features per dimension.

__Problem:__
The function `sparse_repeats` and `sparse_tile` in `kronecker.py` are used to compute the Kuf matrix in the kronecker case. For example, letting `A1 = [B, C, D].T`, `A2 = [E, F].T` be the Kuf matrices corresponding to two different dimensions, each with different number of inducing features (3 and 2), then the total Kuf matrix should be computed as:

B B C C D D    (`sparse_repeats(A=A1, repeats=A2.shape[0])`)
x
E F E F E F     (`sparse_tile(A=A2, repeats=A1.shape[0])`)
\=
BE BF CE CF DE DF

However, running `sparse_tile(A=A2, repeats=A1.shape[0])`, to compute the second matrix, the line
```
for i in range(0, repeats):
        row[i*n:(i+1)*n] = A.row + i*repeats
```
(see lines 22-23 in `kronecker.py`) results in a matrix that looks like
E F _ E F _ E F _
instead of
E F E F E F
since it increments the rows by `A1.shape[0]=3` steps instead of what should be 2.

__Solution:__
The row increment should be multiples of `A.shape[0]` instead of `repeats`, i.e. the above should be

```
for i in range(0, repeats):
        row[i*n:(i+1)*n] = A.row + i*A.shape[0]
```
